### PR TITLE
Allowing messages to be sent synchronously

### DIFF
--- a/log4net.Rollbar/log4net.Rollbar.csproj
+++ b/log4net.Rollbar/log4net.Rollbar.csproj
@@ -38,8 +38,8 @@
     <Reference Include="Newtonsoft.Json">
       <HintPath>..\packages\Newtonsoft.Json.5.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
     </Reference>
-    <Reference Include="RollbarSharp">
-      <HintPath>..\packages\RollbarSharp.0.3.1.0\lib\net40\RollbarSharp.dll</HintPath>
+    <Reference Include="RollbarSharp, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\RollbarSharp.1.0.0.0\lib\net45\RollbarSharp.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Configuration" />

--- a/log4net.Rollbar/packages.config
+++ b/log4net.Rollbar/packages.config
@@ -2,5 +2,5 @@
 <packages>
   <package id="log4net" version="2.0.3" targetFramework="net45" />
   <package id="Newtonsoft.Json" version="5.0.1" targetFramework="net45" />
-  <package id="RollbarSharp" version="0.3.1.0" targetFramework="net45" />
+  <package id="RollbarSharp" version="1.0.0.0" targetFramework="net45" />
 </packages>


### PR DESCRIPTION
Hello and thank you for your library! At our work we include gifs with every PR so here is a happy one:

![Yay](http://i.giphy.com/TSn2zVInxOm2c.gif)

This PR is to optionally allow messages to be sent synchronously. We recently started using `log4net.Rollbar` within an application that would log a message then immediately exit. If messages are sent asynchronously (the current default) they may not get sent before the application stops, leading to missed messages.

This change allows messages to be optionally sent synchronously to avoid this issue entirely. The default is still to send messages asynchronously.
